### PR TITLE
Add download entries and Discord redirect

### DIFF
--- a/app/discord/route.ts
+++ b/app/discord/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+const DISCORD_INVITE = 'https://discord.gg/WYbPYDhQ8y';
+
+export function GET() {
+  return NextResponse.redirect(DISCORD_INVITE, { status: 308 });
+}
+
+export const HEAD = GET;

--- a/app/en/discord/route.ts
+++ b/app/en/discord/route.ts
@@ -1,0 +1,1 @@
+export { GET, HEAD } from '../../discord/route';

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -35,7 +35,7 @@ export function Footer({ locale = 'pt' }: FooterProps) {
           <div className="flex flex-wrap gap-3">
             <FooterLink href="https://github.com/amathyzin" icon={<GithubLogo size={18} weight="bold" />}>GitHub</FooterLink>
             <FooterLink href="https://www.youtube.com/@aMathyzin" icon={<YoutubeLogo size={18} weight="bold" />}>YouTube</FooterLink>
-            <FooterLink href="https://amathyzin.com/discord" icon={<DiscordLogo size={18} weight="bold" />}>Discord</FooterLink>
+            <FooterLink href="/discord" icon={<DiscordLogo size={18} weight="bold" />}>Discord</FooterLink>
           </div>
         </div>
         <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">

--- a/src/content/downloads-listing.ts
+++ b/src/content/downloads-listing.ts
@@ -14,7 +14,7 @@ export const downloadListingPt: DownloadListingItem[] = [
     actions: [
       {
         label: 'Download via Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       },
@@ -59,7 +59,7 @@ export const downloadListingPt: DownloadListingItem[] = [
     videoEmbed: 'https://www.youtube.com/embed/ciHfcpppItg',
     actions: [
       { label: 'Ver projeto', url: '/downloads/haunted', type: 'primary' },
-      { label: 'Servidor Discord', url: 'https://amathyzin.com/discord', type: 'discord', external: true }
+      { label: 'Servidor Discord', url: '/discord', type: 'discord', external: true }
     ],
     tags: ['haunted', 'miguelin', 'batch']
   },
@@ -77,6 +77,20 @@ export const downloadListingPt: DownloadListingItem[] = [
     tags: ['batchclick', 'batch', 'otimizacao']
   },
   {
+    id: 'autonetv1',
+    slug: 'autonetv1',
+    title: 'Autonet',
+    description:
+      'Otimizador de rede avançado que ajusta MTU, RWIN, TTL e prioridades para reduzir latência e estabilizar conexões.',
+    category: 'Rede',
+    videoEmbed: 'https://www.youtube.com/embed/0J4nhSur9DI',
+    actions: [
+      { label: 'Ver projeto', url: '/downloads/autonetv1', type: 'primary' },
+      { label: 'Servidor Discord', url: '/discord', type: 'discord', external: true }
+    ],
+    tags: ['autonet', 'rede', 'latencia']
+  },
+  {
     id: 'minimal-optimizer',
     title: 'Minimal Optimizer',
     description: 'Painel eficiente desenvolvido pela comunidade para ajustes rápidos.',
@@ -85,7 +99,7 @@ export const downloadListingPt: DownloadListingItem[] = [
     actions: [
       {
         label: 'Mais informações no Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       },
@@ -125,6 +139,20 @@ export const downloadListingPt: DownloadListingItem[] = [
       { label: 'Senha', url: 'https://fir3.net/SenhaFPSV3', type: 'password', external: true }
     ],
     tags: ['fps', 'pack']
+  },
+  {
+    id: 'valorantbooster1',
+    slug: 'valorantbooster1',
+    title: 'Valorant Booster',
+    description:
+      'Ferramenta que ajusta configurações do Windows para aumentar o FPS e estabilizar partidas no Valorant.',
+    category: 'Games',
+    videoEmbed: 'https://www.youtube.com/embed/7qV-fDkxeVc',
+    actions: [
+      { label: 'Ver projeto', url: '/downloads/valorantbooster1', type: 'primary' },
+      { label: 'GitHub', url: 'https://github.com/aMathyzin/Valorant-Booster-Alpha', type: 'source', external: true }
+    ],
+    tags: ['valorant', 'fps', 'windows']
   },
   {
     id: 'storageclean',
@@ -215,7 +243,7 @@ export const downloadListingEn: DownloadListingItem[] = [
       url: 'https://www.youtube.com/watch?v=RzapmonmPp4'
     },
     actions: [
-      { label: 'Download on Discord', url: 'https://amathyzin.com/discord', type: 'discord', external: true },
+      { label: 'Download on Discord', url: '/en/discord', type: 'discord', external: true },
       { label: 'Source code', url: 'https://github.com/aMathyzin/aMathyBoost', type: 'source', external: true }
     ],
     highlight: 'Compatible with any hardware',
@@ -243,7 +271,7 @@ export const downloadListingEn: DownloadListingItem[] = [
     videoEmbed: 'https://www.youtube.com/embed/ciHfcpppItg',
     actions: [
       { label: 'View project', url: '/en/downloads/haunted', type: 'primary' },
-      { label: 'Discord server', url: 'https://amathyzin.com/discord', type: 'discord', external: true }
+      { label: 'Discord server', url: '/en/discord', type: 'discord', external: true }
     ],
     tags: ['haunted', 'miguelin', 'batch']
   },
@@ -261,13 +289,27 @@ export const downloadListingEn: DownloadListingItem[] = [
     tags: ['batchclick', 'automation']
   },
   {
+    id: 'autonetv1',
+    slug: 'autonetv1',
+    title: 'Autonet',
+    description:
+      'Advanced network optimizer that tunes MTU, RWIN, TTL and priorities to reduce latency and stabilize connections.',
+    category: 'Network',
+    videoEmbed: 'https://www.youtube.com/embed/0J4nhSur9DI',
+    actions: [
+      { label: 'View project', url: '/en/downloads/autonetv1', type: 'primary' },
+      { label: 'Discord server', url: '/en/discord', type: 'discord', external: true }
+    ],
+    tags: ['autonet', 'network', 'latency']
+  },
+  {
     id: 'minimal-optimizer',
     title: 'Minimal Optimizer',
     description: 'Lightweight dashboard maintained by the community for quick adjustments.',
     category: 'Windows',
     videoEmbed: 'https://www.youtube.com/embed/GG9ORzRMSrc',
     actions: [
-      { label: 'More details on Discord', url: 'https://amathyzin.com/discord', type: 'discord', external: true },
+      { label: 'More details on Discord', url: '/en/discord', type: 'discord', external: true },
       { label: 'Source code', url: 'https://github.com/Matheusdamoda/Minimal-Optimizer', type: 'source', external: true }
     ],
     tags: ['minimal optimizer']
@@ -299,6 +341,19 @@ export const downloadListingEn: DownloadListingItem[] = [
       { label: 'Password', url: 'https://fir3.net/SenhaFPSV3', type: 'password', external: true }
     ],
     tags: ['fpspack', 'firstboost']
+  },
+  {
+    id: 'valorantbooster1',
+    slug: 'valorantbooster1',
+    title: 'Valorant Booster',
+    description: 'Tool that adjusts Windows settings to raise FPS and stabilize Valorant matches.',
+    category: 'Games',
+    videoEmbed: 'https://www.youtube.com/embed/7qV-fDkxeVc',
+    actions: [
+      { label: 'View project', url: '/en/downloads/valorantbooster1', type: 'primary' },
+      { label: 'GitHub', url: 'https://github.com/aMathyzin/Valorant-Booster-Alpha', type: 'source', external: true }
+    ],
+    tags: ['valorant', 'booster', 'windows']
   },
   {
     id: 'storageclean',

--- a/src/content/locales/en.ts
+++ b/src/content/locales/en.ts
@@ -163,7 +163,7 @@ export const homeContentEn: HomeContent = {
     title: 'Join our community',
     description:
       'Get tailored support, giveaways and live monitoring sessions on the official Discord server.',
-    cta: { label: 'Join Discord', href: 'https://amathyzin.com/discord' },
+    cta: { label: 'Join Discord', href: '/en/discord' },
     widgetUrl: 'https://discord.com/widget?id=1210446694953779260&theme=dark'
   }
 };
@@ -191,7 +191,7 @@ export const aboutContentEn: AboutContent = {
   community: {
     description:
       'Join our Discord server to receive support, follow releases, take part in giveaways and contribute with feedback.',
-    cta: { label: 'Join Discord', href: 'https://amathyzin.com/discord' }
+    cta: { label: 'Join Discord', href: '/en/discord' }
   }
 };
 

--- a/src/content/locales/pt.ts
+++ b/src/content/locales/pt.ts
@@ -163,7 +163,7 @@ export const homeContentPt: HomeContent = {
     title: 'Participe da nossa comunidade',
     description:
       'Acesse suporte personalizado, sorteios e sessões de monitoramento em tempo real dentro do servidor oficial no Discord.',
-    cta: { label: 'Entrar no Discord', href: 'https://amathyzin.com/discord' },
+    cta: { label: 'Entrar no Discord', href: '/discord' },
     widgetUrl: 'https://discord.com/widget?id=1210446694953779260&theme=dark'
   }
 };
@@ -190,7 +190,7 @@ export const aboutContentPt: AboutContent = {
   ],
   community: {
     description: 'Participe do nosso servidor no Discord para receber suporte, acompanhar lançamentos, participar de sorteios e contribuir com feedbacks.',
-    cta: { label: 'Entrar no Discord', href: 'https://amathyzin.com/discord' }
+    cta: { label: 'Entrar no Discord', href: '/discord' }
   }
 };
 

--- a/src/content/projects-en.ts
+++ b/src/content/projects-en.ts
@@ -64,7 +64,7 @@ export const downloadProjectsEn: DownloadProject[] = [
       },
       {
         label: 'Discord community',
-        url: 'https://amathyzin.com/discord',
+        url: '/en/discord',
         type: 'discord',
         external: true
       }
@@ -143,7 +143,7 @@ export const downloadProjectsEn: DownloadProject[] = [
       },
       {
         label: 'Download on Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/en/discord',
         type: 'discord',
         external: true
       },
@@ -241,7 +241,7 @@ export const downloadProjectsEn: DownloadProject[] = [
       },
       {
         label: 'Discord server',
-        url: 'https://amathyzin.com/discord',
+        url: '/en/discord',
         type: 'discord',
         external: true
       }
@@ -326,7 +326,7 @@ export const downloadProjectsEn: DownloadProject[] = [
       },
       {
         label: 'Discord server',
-        url: 'https://amathyzin.com/discord',
+        url: '/en/discord',
         type: 'discord',
         external: true
       }
@@ -412,7 +412,7 @@ export const downloadProjectsEn: DownloadProject[] = [
       },
       {
         label: 'Discord server',
-        url: 'https://amathyzin.com/discord',
+        url: '/en/discord',
         type: 'discord',
         external: true
       }
@@ -480,7 +480,7 @@ export const downloadProjectsEn: DownloadProject[] = [
     downloads: [
       {
         label: 'Download on Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/en/discord',
         type: 'discord',
         external: true
       }

--- a/src/content/projects-pt.ts
+++ b/src/content/projects-pt.ts
@@ -64,7 +64,7 @@ export const downloadProjectsPt: DownloadProject[] = [
       },
       {
         label: 'Comunidade no Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       }
@@ -143,7 +143,7 @@ export const downloadProjectsPt: DownloadProject[] = [
       },
       {
         label: 'Download via Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       },
@@ -241,7 +241,7 @@ export const downloadProjectsPt: DownloadProject[] = [
       },
       {
         label: 'Servidor no Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       }
@@ -326,7 +326,7 @@ export const downloadProjectsPt: DownloadProject[] = [
       },
       {
         label: 'Servidor no Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       }
@@ -412,7 +412,7 @@ export const downloadProjectsPt: DownloadProject[] = [
       },
       {
         label: 'Servidor no Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       }
@@ -480,7 +480,7 @@ export const downloadProjectsPt: DownloadProject[] = [
     downloads: [
       {
         label: 'Download via Discord',
-        url: 'https://amathyzin.com/discord',
+        url: '/discord',
         type: 'discord',
         external: true
       }


### PR DESCRIPTION
## Summary
- add redirect handlers for `/discord` and `/en/discord` pointing to the community invite
- expand the downloads listing with Autonet and Valorant Booster cards and point Discord actions to the new endpoint
- update localized content and footer links to consume the internal Discord redirect

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cdc5f991108321976c354a3b534af2